### PR TITLE
Add support for PC-lint inhibition in the form of next/current expression/statement

### DIFF
--- a/src/main/java/rortveiten/misra/PcLintWarningParser.java
+++ b/src/main/java/rortveiten/misra/PcLintWarningParser.java
@@ -79,7 +79,7 @@ public class PcLintWarningParser extends WarningParser {
 
 	@Override
 	protected Set<String> getGuidelineIdsFromComment(String comment) {
-		Matcher matcher = Pattern.compile("\\G[-!]e(?:sym\\(|func\\(|macro\\(|file\\(|template\\(|string\\(|call\\(|type\\()?(\\d+)(:?,[^\\)]*\\)\\s*|\\s*)").matcher(comment);
+		Matcher matcher = Pattern.compile("\\G[-!]e(?:\\(|\\{|sym\\(|func\\(|macro\\(|file\\(|template\\(|string\\(|call\\(|type\\()?(\\d+)(:?,[^\\)]*\\)\\s*|\\s*)").matcher(comment);
 		Set<String> ret = new HashSet<String>();
 		while (matcher.find()) {
 			Integer errNo = Integer.decode(matcher.group(1));

--- a/src/main/java/rortveiten/misra/PcLintWarningParser.java
+++ b/src/main/java/rortveiten/misra/PcLintWarningParser.java
@@ -79,7 +79,7 @@ public class PcLintWarningParser extends WarningParser {
 
 	@Override
 	protected Set<String> getGuidelineIdsFromComment(String comment) {
-		Matcher matcher = Pattern.compile("\\G[-!]e(?:\\(|\\{|sym\\(|func\\(|macro\\(|file\\(|template\\(|string\\(|call\\(|type\\()?(\\d+)(:?,[^\\)]*\\)\\s*|\\s*)").matcher(comment);
+		Matcher matcher = Pattern.compile("\\G-?[-!]e(?:\\(|\\{|sym\\(|func\\(|macro\\(|file\\(|template\\(|string\\(|call\\(|type\\()?(\\d+)(:?,[^\\)]*\\)\\s*|(\\)|\\})\\s*|\\s*)").matcher(comment);
 		Set<String> ret = new HashSet<String>();
 		while (matcher.find()) {
 			Integer errNo = Integer.decode(matcher.group(1));

--- a/src/test/java/rortveiten/misra/PcLintWarningParserTest.java
+++ b/src/test/java/rortveiten/misra/PcLintWarningParserTest.java
@@ -118,9 +118,13 @@ public class PcLintWarningParserTest {
 	public void getGuidelineIdWithMultipleSuppressions() {
 		PcLintWarningParser parser = new PcLintWarningParser();
 		parser.setMisraVersion(MisraVersion.C_2012);
-		Set<String> reqIds = parser.getGuidelineIdsFromComment("-esym(16,rai) !e9015 -emacro(484,hei) -efunc(9024, jau) -efile(9029, hau) Hello -e4444444");//Last one is ignored because of the text inbetween
+		Set<String> reqIds = parser.getGuidelineIdsFromComment("-e(774) --e(9018) -e{9019} --e{9051} -esym(16,rai) !e9015 -emacro(484,hei) -efunc(9024, jau) -efile(9029, hau) Hello -e4444444");//Last one is ignored because of the text inbetween
 		
-		assertEquals(5, reqIds.size());
+		assertEquals(9, reqIds.size());
+		assertTrue(reqIds.contains("Rule 14.3"));
+		assertTrue(reqIds.contains("Rule 19.2"));
+		assertTrue(reqIds.contains("Rule 20.1"));
+		assertTrue(reqIds.contains("Rule 20.4"));
 		assertTrue(reqIds.contains("Rule 20.13"));
 		assertTrue(reqIds.contains("Rule 20.12"));
         assertTrue(reqIds.contains("Rule 20.10"));


### PR DESCRIPTION
PC lint Error Inhibition in the following forms (still only first message id):
-e(# [ ,# ]... )
--e( # [ ,# ]... )
-e{ # [ , # ] … }
--e{ # [ , # ] … }